### PR TITLE
Improved layout on smaller devices

### DIFF
--- a/src/DialectPicker.scala
+++ b/src/DialectPicker.scala
@@ -39,7 +39,7 @@ class DialectPicker() {
 
   /** Dialect picker component */
   val node = div(
-    cls := "flex flex-row gap-2 mb-2",
+    cls := "flex flex-row gap-2 mb-2 flex-wrap",
     p(
       cls := "text-md",
       "Scala dialect:"

--- a/src/index.scala
+++ b/src/index.scala
@@ -115,17 +115,24 @@ val basicLink =
   cls := "text-emerald-800 hover:no-underline underline"
 
 val header = div(
-  cls := "flex flex-row gap-4 place-content-between w-full",
+  cls := "flex flex-col sm:flex-row sm:gap-4 place-content-between w-full",
   p(
     cls := "text-md",
     "Understand your scala code"
   ),
   p(
-    cls := "text-sm",
+    cls := "text-sm inline",
     a(
-      "Github",
+      cls := "inline-block",
       href := "https://github.com/majk-p/scala-explainer",
-      basicLink
+      basicLink,
+      svg.svg(
+        svg.cls := "size-4 mr-1 inline align-sub",
+        svg.viewBox := "0 0 48 48",
+        svg.xmlns := "http://www.w3.org/2000/svg",
+        svg.path(svg.d := "M24,1.9a21.6,21.6,0,0,0-6.8,42.2c1,.2,1.8-.9,1.8-1.8V39.4c-6,1.3-7.9-2.9-7.9-2.9a6.5,6.5,0,0,0-2.2-3.2C6.9,31.9,9,32,9,32a4.3,4.3,0,0,1,3.3,2c1.7,2.9,5.5,2.6,6.7,2.1a5.4,5.4,0,0,1,.5-2.9C12.7,32,9,28,9,22.6A10.7,10.7,0,0,1,11.9,15a6.2,6.2,0,0,1,.3-6.4,8.9,8.9,0,0,1,6.4,2.9,15.1,15.1,0,0,1,5.4-.8,17.1,17.1,0,0,1,5.4.7,9,9,0,0,1,6.4-2.8,6.5,6.5,0,0,1,.4,6.4A10.7,10.7,0,0,1,39,22.6C39,28,35.3,32,28.5,33.2a5.4,5.4,0,0,1,.5,2.9v6.2a1.8,1.8,0,0,0,1.9,1.8A21.7,21.7,0,0,0,24,1.9Z")
+      ),
+      "GitHub"
     ),
     " | ",
     " Standing on the shoulders of giants: ",


### PR DESCRIPTION
What was changed:
1. Added Github logo to improve link readability
2. Section with links now collapses into the columns on smaller devices (<640px)

Before:
1020px
<img width="1201" alt="Screenshot 2025-04-13 at 12 41 19" src="https://github.com/user-attachments/assets/949256cb-fc0a-4b39-af25-52ac16c7bf39" />
400px
<img width="398" alt="Screenshot 2025-04-13 at 12 08 43" src="https://github.com/user-attachments/assets/a83a8e99-64ab-4e53-b875-820bf585598a" />
After:
1200px
<img width="1190" alt="Screenshot 2025-04-13 at 12 41 06" src="https://github.com/user-attachments/assets/bfe5153f-808a-41f5-9576-80b02e4d14c6" />
400px
<img width="400" alt="Screenshot 2025-04-13 at 12 40 21" src="https://github.com/user-attachments/assets/332c9777-a58b-4a90-8087-d0bb0c18623c" />
